### PR TITLE
Expose default client variable

### DIFF
--- a/restclient.go
+++ b/restclient.go
@@ -229,10 +229,10 @@ func complain(err error, status int, rawtext string) {
 }
 
 var (
-	defaultClient = New()
+	DefaultClient = New()
 )
 
 // Do executes a REST request using the default client.
 func Do(r *RequestResponse) (status int, err error) {
-	return defaultClient.Do(r)
+	return DefaultClient.Do(r)
 }


### PR DESCRIPTION
Exposing the default client variable makes it possible to access restclient's `http.Client`. 
With access to this you could stub responses by setting a custom `http.Transport` interface in your tests with something like this:

``` go
type FakeTransport struct {
  http.Transport
}

func (m *FakeTransport) RoundTrip(req *http.Request) (*http.Response, error){
  response := new(http.Response)
  response.StatusCode = 200
  response.Body = body_for(req.URL)

  return response, nil
}

...

restclient.DefaultClient.HttpClient.Transport = my_fake_transport
```

---

I am really new to Go and was looking into request stubbing when starting to write a API client using restclient. I think this is kind of a nice way to do that without having to use `net/http/httptest` when you just want to stub a response. 

Atleast it can be good to allow access to restclient's `http.Client` as it is configurable. Maybe there is a better way to do this? :blush:

Anyway, let me know what you think! 
