### PR TITLE
trim whitespace off of the raw response.  

### DIFF
--- a/client.go
+++ b/client.go
@@ -173,7 +173,7 @@ func (c *Client) Do(rr *RequestResponse) (status int, err error) {
 		log.Println(err)
 		return
 	}
-	rr.RawText = string(data)
+	rr.RawText = strings.TrimSpace(string(data))
 	json.Unmarshal(data, &rr.Error) // Ignore errors
 	if rr.RawText != "" && status < 300 {
 		err = json.Unmarshal(data, &rr.Result) // Ignore errors


### PR DESCRIPTION
There are cases where the response body may come back as " ".  This fails the check to see if the response is empty and tries to unmarshal the response, which fails.
