### PR TITLE
Make query parameters available for all verbs, per Issue #12.

### DIFF
--- a/request.go
+++ b/request.go
@@ -23,7 +23,7 @@ type Params map[string]string
 type Request struct {
 	Url     string      // Raw URL string
 	Method  string      // HTTP method to use
-	Params  *Params     // URL parameters for GET requests (ignored otherwise)
+	Params  *Params     // URL query parameters
 	Payload interface{} // Data to JSON-encode and POST
 
 	// Result is a pointer to a data structure.  On success (HTTP status < 300),

--- a/session.go
+++ b/session.go
@@ -47,10 +47,10 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 		return
 	}
 	//
-	// If we are making a GET request and the user populated the Params field, then
-	// add the params to the URL's querystring.
+	// If the user populated the Params field, then add the params to the URL's
+	// querystring.
 	//
-	if r.Method == "GET" && r.Params != nil {
+	if r.Params != nil {
 		vals := u.Query()
 		for k, v := range *r.Params {
 			vals.Set(k, v)


### PR DESCRIPTION
Formerly, query parameters were honored only with GET, and were intentionally ignored with all other verbs.  However Issue #12 pointed out that this is not correct behavior.

This PR removes that restriction, and makes it possible to use query parameters regardless of verb.
