### PR TITLE
Respect "Silence is golden" rule, disable WARNING

### DIFF
--- a/session.go
+++ b/session.go
@@ -136,7 +136,7 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 	if userinfo != nil {
 		pwd, _ := userinfo.Password()
 		req.SetBasicAuth(userinfo.Username(), pwd)
-		if u.Scheme != "https" {
+		if u.Scheme != "https" && s.Log {
 			log.Println("WARNING: Using HTTP Basic Auth in cleartext is insecure.")
 		}
 	}


### PR DESCRIPTION
It's the user's responsibility to ensure that he's hitting an `https` endpoint, not the library's IMHO.

Plus the `WARNING: *` is very verbose in tests or logs.

I would personally vote for it to be removed, or otherwise like above wrap it with the `.Log` conditional
