### PR TITLE
Fix/noise

### DIFF
--- a/session.go
+++ b/session.go
@@ -147,9 +147,9 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 		log.Println("--------------------------------------------------------------------------------")
 		log.Println("REQUEST")
 		log.Println("--------------------------------------------------------------------------------")
-		prettyPrint(req)
+		log.Println(pretty(req))
 		log.Print("Payload: ")
-		prettyPrint(r.Payload)
+		log.Println(pretty(r.Payload))
 	}
 	r.timestamp = time.Now()
 	var client *http.Client
@@ -190,14 +190,14 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 		log.Println("--------------------------------------------------------------------------------")
 		log.Println("Status: ", response.status)
 		log.Println("Header:")
-		prettyPrint(response.HttpResponse().Header)
+		log.Println(pretty(response.HttpResponse().Header))
 		log.Println("Body:")
 		if response.body != nil {
 			raw := json.RawMessage{}
 			if json.Unmarshal(response.body, &raw) == nil {
-				prettyPrint(&raw)
+				log.Println(pretty(&raw))
 			} else {
-				prettyPrint(response.RawText())
+				log.Println(pretty(response.RawText()))
 			}
 		} else {
 			log.Println("Empty response body")

--- a/session.go
+++ b/session.go
@@ -149,7 +149,8 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 	s.log("REQUEST")
 	s.log("--------------------------------------------------------------------------------")
 	s.log(pretty(req))
-	s.log("Payload:", pretty(r.Payload))
+	s.log("Payload:")
+	s.log(pretty(r.Payload))
 
 	r.timestamp = time.Now()
 	var client *http.Client

--- a/session.go
+++ b/session.go
@@ -44,8 +44,8 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 	//
 	u, err := url.Parse(r.Url)
 	if err != nil {
-		log.Println("URL", r.Url)
-		log.Println(err)
+		s.log("URL", r.Url)
+		s.log(err)
 		return
 	}
 	//
@@ -89,20 +89,20 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 		var b []byte
 		b, err = json.Marshal(&r.Payload)
 		if err != nil {
-			log.Println(err)
+			s.log(err)
 			return
 		}
 		buf := bytes.NewBuffer(b)
 		req, err = http.NewRequest(r.Method, u.String(), buf)
 		if err != nil {
-			log.Println(err)
+			s.log(err)
 			return
 		}
 		header.Add("Content-Type", "application/json")
 	} else { // no data to encode
 		req, err = http.NewRequest(r.Method, u.String(), nil)
 		if err != nil {
-			log.Println(err)
+			s.log(err)
 			return
 		}
 
@@ -160,7 +160,7 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Println(err)
+		s.log(err)
 		return
 	}
 	defer resp.Body.Close()
@@ -171,7 +171,7 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 	//
 	r.body, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Println(err)
+		s.log(err)
 		return
 	}
 	if string(r.body) != "" {
@@ -197,12 +197,12 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 	if response.body != nil {
 		raw := json.RawMessage{}
 		if json.Unmarshal(response.body, &raw) == nil {
-			log.Println(pretty(&raw))
+			s.log(pretty(&raw))
 		} else {
-			log.Println(pretty(response.RawText()))
+			s.log(pretty(response.RawText()))
 		}
 	} else {
-		log.Println("Empty response body")
+		s.log("Empty response body")
 	}
 
 	return

--- a/util.go
+++ b/util.go
@@ -7,17 +7,21 @@ package napping
 
 import (
 	"encoding/json"
-	"os"
+	"fmt"
 	"path/filepath"
 	"runtime"
-	"strconv"
 )
 
-func prettyPrint(v interface{}) {
+func pretty(v interface{}) string {
+	// Get source file and line
 	_, file, line, _ := runtime.Caller(1)
-	lineNo := strconv.Itoa(line)
-	file = filepath.Base(file)
+
+	// Get relative filename
+	filename := filepath.Base(file)
+
+	// Convert to JSON
 	b, _ := json.MarshalIndent(v, "", "\t")
-	s := file + ":" + lineNo + ": \n" + string(b) + "\n"
-	os.Stderr.WriteString(s)
+
+	// Make that all pretty together
+	return fmt.Sprintf("%s:%d: \n%s\n", filename, line, string(b))
 }


### PR DESCRIPTION
This PR does a few things :

* Simplifies logging code by removing conditionals spread everywhere
* Centralizes all logging in one method `Session.log` so it can easily be switched on/off using the `.Log` attribute
* Switches request/response logging over to `s.log`
* And importantly switches error logging over to `s.log` which is important, so that when `Session.Log` is `false` no errors are printed to `stderr`

The last one is important because in production it's the callers responsibility to handle the error object returned, in some cases we might retry or something and we don't want to pollute the logs with errors that we handle.