### PR TITLE
moved gopass dependency to github

### DIFF
--- a/examples/github_auth_token/github_auth_token.go
+++ b/examples/github_auth_token/github_auth_token.go
@@ -37,7 +37,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	passwd, err := gopass.GetPass("Github password: ")
+	fmt.Printf("github.com/howeyc/gopass")
+	passwd := gopass.GetPasswd()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -83,7 +84,7 @@ func main() {
 	// can also be configured on a per-request basis when using Send().
 	//
 	s := napping.Session{
-		Userinfo: url.UserPassword(username, passwd),
+		Userinfo: url.UserPassword(username, string(passwd)),
 	}
 	url := "https://api.github.com/authorizations"
 	//

--- a/examples/github_auth_token/github_auth_token.go
+++ b/examples/github_auth_token/github_auth_token.go
@@ -14,8 +14,8 @@ NOTE: This example may only work on *nix systems due to gopass requirements.
 */
 
 import (
-	"code.google.com/p/gopass"
 	"fmt"
+	"github.com/howeyc/gopass"
 	"github.com/jmcvetta/napping"
 	"github.com/kr/pretty"
 	"log"


### PR DESCRIPTION
Hey! I was looking through some code to update dependencies for the `code.google.com` shutdown, and noticed that you have one of those soon-dead imports hanging out in your example code. I found a seemingly-equivalent library to use instead, that's on Github.