### PR TITLE
Provides a method to capture the raw response body.

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -304,6 +304,35 @@ func TestRawRequestInvalidType(t *testing.T) {
 	}
 }
 
+// TestRawResponse tests capturing the raw response body.
+func TestRawResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(HandleRaw))
+	defer srv.Close()
+
+	var payload = bytes.NewBufferString("napping")
+	req := Request{
+		Url:                 "http://" + srv.Listener.Addr().String(),
+		Method:              "PUT",
+		RawPayload:          true,
+		CaptureResponseBody: true,
+		Payload:             payload,
+	}
+
+	resp, err := Send(&req)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, resp.Status(), 200)
+	rawResponseStruct := structType{
+		Foo: 0,
+		Bar: "napping",
+	}
+
+	blob, err := json.Marshal(rawResponseStruct)
+	assert.Equal(t, bytes.Equal(resp.ResponseBody.Bytes(), blob), true)
+}
+
 func JsonError(w http.ResponseWriter, msg string, code int) {
 	e := errorStruct{
 		Status:  code,

--- a/request.go
+++ b/request.go
@@ -6,6 +6,7 @@
 package napping
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -33,6 +34,12 @@ type Request struct {
 	// Result is a pointer to a data structure.  On success (HTTP status < 300),
 	// response from server is unmarshaled into Result.
 	Result interface{}
+
+	// CaptureResponseBody can be set to capture the response body for external use.
+	CaptureResponseBody bool
+
+	// ResponseBody exports the raw response body if CaptureResponseBody is true.
+	ResponseBody *bytes.Buffer
 
 	// Error is a pointer to a data structure.  On error (HTTP status >= 300),
 	// response from server is unmarshaled into Error.

--- a/session.go
+++ b/session.go
@@ -12,9 +12,9 @@ requests (cookies, auth, proxies).
 
 import (
 	"bytes"
-	"errors"
-	"encoding/json"
 	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -204,6 +204,9 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 		if resp.StatusCode >= 400 && r.Error != nil {
 			json.Unmarshal(r.body, r.Error) // Should we ignore unmarshall error?
 		}
+	}
+	if r.CaptureResponseBody {
+		r.ResponseBody = bytes.NewBuffer(r.body)
 	}
 	rsp := Response(*r)
 	response = &rsp


### PR DESCRIPTION
Greetings! I have a need to capture the raw response body. In my case I cannot use the json library to unmarshal the response, so I'm proposing this as a way of exposing the response body as a buffer. It only copies the body if you set a boolean parameter, so it shouldn't have much affect on typical usage.

Thanks!
