### PR TITLE
GET api: use url.Values instead of napping.Params

### DIFF
--- a/api.go
+++ b/api.go
@@ -9,7 +9,9 @@ package napping
 This module implements the Napping API.
 */
 
-import ()
+import (
+	"net/url"
+)
 
 // Send composes and sends and HTTP request.
 func Send(r *Request) (*Response, error) {
@@ -18,7 +20,7 @@ func Send(r *Request) (*Response, error) {
 }
 
 // Get sends a GET request.
-func Get(url string, p *Params, result, errMsg interface{}) (*Response, error) {
+func Get(url string, p *url.Values, result, errMsg interface{}) (*Response, error) {
 	s := Session{}
 	return s.Get(url, p, result, errMsg)
 }

--- a/api_test.go
+++ b/api_test.go
@@ -68,7 +68,7 @@ func TestGet(t *testing.T) {
 	// Good request
 	//
 	url := "http://" + srv.Listener.Addr().String()
-	p := fooParams
+	p := fooParams.AsUrlValues()
 	res := structType{}
 	resp, err := Get(url, &p, &res, nil)
 	if err != nil {
@@ -80,7 +80,7 @@ func TestGet(t *testing.T) {
 	// Bad request
 	//
 	url = "http://" + srv.Listener.Addr().String()
-	p = Params{"bad": "value"}
+	p = Params{"bad": "value"}.AsUrlValues()
 	e := errorStruct{}
 	resp, err = Get(url, &p, nil, nil)
 	if err != nil {
@@ -106,7 +106,7 @@ func TestDefaultParams(t *testing.T) {
 	// Good request
 	//
 	url := "http://" + srv.Listener.Addr().String()
-	p := fooParams
+	p := fooParams.AsUrlValues()
 	res := structType{}
 	s := Session{
 		Params: &p,
@@ -121,7 +121,7 @@ func TestDefaultParams(t *testing.T) {
 	// Bad request
 	//
 	url = "http://" + srv.Listener.Addr().String()
-	p = Params{"bad": "value"}
+	p = Params{"bad": "value"}.AsUrlValues()
 	e := errorStruct{}
 	resp, err = Get(url, &p, nil, nil)
 	if err != nil {

--- a/examples/httpbin/httpbin.go
+++ b/examples/httpbin/httpbin.go
@@ -64,8 +64,7 @@ func main() {
 
 	url = "http://httpbin.org/get"
 	fmt.Println("URL:>", url)
-	fooParams := napping.Params{"foo": "bar"}
-	p := fooParams
+	p := napping.Params{"foo": "bar"}.AsUrlValues()
 
 	res = ResponseUserAgent{}
 	resp, err = s.Get(url, &p, &res, nil)

--- a/request.go
+++ b/request.go
@@ -16,6 +16,15 @@ import (
 // A Params is a map containing URL parameters.
 type Params map[string]string
 
+func (p Params) AsUrlValues() url.Values {
+	result := url.Values{}
+	for key,value := range p {
+		result.Set(key,value)
+	}
+	return result
+}
+
+
 // A Request describes an HTTP request to be executed, data structures into
 // which the result will be unmarshalled, and the server's response. By using
 // a  single object for both the request and the response we allow easy access
@@ -23,7 +32,7 @@ type Params map[string]string
 type Request struct {
 	Url     string      // Raw URL string
 	Method  string      // HTTP method to use
-	Params  *Params     // URL query parameters
+	Params  *url.Values     // URL query parameters
 	Payload interface{} // Data to JSON-encode and POST
 
 	// Can be set to true if Payload is of type *bytes.Buffer and client wants

--- a/session.go
+++ b/session.go
@@ -34,7 +34,7 @@ type Session struct {
 
 	// Optional defaults - can be overridden in a Request
 	Header *http.Header
-	Params *Params
+	Params *url.Values
 }
 
 // Send constructs and sends an HTTP request.
@@ -53,7 +53,7 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 	//
 	// Default query parameters
 	//
-	p := Params{}
+	p := url.Values{}
 	if s.Params != nil {
 		for k, v := range *s.Params {
 			p[k] = v
@@ -70,11 +70,7 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 	//
 	// Encode parameters
 	//
-	vals := u.Query()
-	for k, v := range p {
-		vals.Set(k, v)
-	}
-	u.RawQuery = vals.Encode()
+	u.RawQuery = p.Encode()
 	//
 	// Create a Request object; if populated, Data field is JSON encoded as
 	// request body
@@ -232,7 +228,7 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 }
 
 // Get sends a GET request.
-func (s *Session) Get(url string, p *Params, result, errMsg interface{}) (*Response, error) {
+func (s *Session) Get(url string, p *url.Values, result, errMsg interface{}) (*Response, error) {
 	r := Request{
 		Method: "GET",
 		Url:    url,

--- a/session_test.go
+++ b/session_test.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -49,14 +50,14 @@ type pair struct {
 	hf hfunc
 }
 
-func paramHandler(t *testing.T, p Params, f hfunc) hfunc {
+func paramHandler(t *testing.T, p url.Values, f hfunc) hfunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if f != nil {
 			f(w, req)
 		}
 		q := req.URL.Query()
 		for k, _ := range p {
-			if p[k] != q.Get(k) {
+			if !assert.Equal(t,p[k],q[k]) {
 				msg := "Bad query params: " + q.Encode()
 				t.Error(msg)
 				return
@@ -166,7 +167,7 @@ func TestRequest(t *testing.T) {
 		// Params
 		//
 		if test.params {
-			p := Params{key: value}
+			p := Params{key: value}.AsUrlValues()
 			f := paramHandler(t, p, nil)
 			allHF = paramHandler(t, p, allHF)
 			r = baseReq


### PR DESCRIPTION
fixes #24 .

The way it's implemented is that api now requires `*url.Values` instead `*napping.Params`, and the new utility method in `napping.Params` allows easy conversion.