### PR TITLE
Session.Send avoids setting duplicate content-type headers

### DIFF
--- a/session.go
+++ b/session.go
@@ -112,7 +112,8 @@ func (s *Session) Send(r *Request) (response *Response, err error) {
 			s.log(err)
 			return
 		}
-		header.Add("Content-Type", "application/json")
+		// Overwrite the content type to json since we're pushing the payload as json
+		header.Set("Content-Type", "application/json")
 	} else { // no data to encode
 		req, err = http.NewRequest(r.Method, u.String(), nil)
 		if err != nil {


### PR DESCRIPTION
Session.Send avoids setting a duplicate content-type header when given a payload. Addresses #37.

I just changed it from headers.Add() to headers.Set(). If it's hard-coded to push the payload as json, and we're going to modify the content-type header, the safest bet is to set it.