### PR TITLE
allow parameters for HTTP DELETE request

### DIFF
--- a/api.go
+++ b/api.go
@@ -56,7 +56,7 @@ func Patch(url string, payload, result, errMsg interface{}) (*Response, error) {
 }
 
 // Delete sends a DELETE request.
-func Delete(url string, result, errMsg interface{}) (*Response, error) {
+func Delete(url string, p *url.Values, result, errMsg interface{}) (*Response, error) {
 	s := Session{}
-	return s.Delete(url, result, errMsg)
+	return s.Delete(url, p, result, errMsg)
 }

--- a/api_test.go
+++ b/api_test.go
@@ -143,7 +143,7 @@ func TestDelete(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(HandleDelete))
 	defer srv.Close()
 	url := "http://" + srv.Listener.Addr().String()
-	resp, err := Delete(url, nil, nil)
+	resp, err := Delete(url, nil, nil, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/session.go
+++ b/session.go
@@ -302,10 +302,11 @@ func (s *Session) Patch(url string, payload, result, errMsg interface{}) (*Respo
 }
 
 // Delete sends a DELETE request.
-func (s *Session) Delete(url string, result, errMsg interface{}) (*Response, error) {
+func (s *Session) Delete(url string, p *url.Values, result, errMsg interface{}) (*Response, error) {
 	r := Request{
 		Method: "DELETE",
 		Url:    url,
+		Params: p,
 		Result: result,
 		Error:  errMsg,
 	}


### PR DESCRIPTION
In order to use the API of our tools with napping, we need the possibility to send parameters with HTTP DELETE requests. This should be compatible with the [HTTP standards](http://www.w3.org/Protocols/rfc2616/rfc2616.txt)
Therefore, I've extended Delete() function's signature to accept url.Values in the same way like Get() does.