### PR TITLE
Remove defunct drone.io CI service badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ library.
 
 ## Status
 
-[![Drone Build Status](https://drone.io/github.com/jmcvetta/napping/status.png)](https://drone.io/github.com/jmcvetta/napping/latest)
 [![Travis Build Status](https://travis-ci.org/jmcvetta/napping.png)](https://travis-ci.org/jmcvetta/napping)
 [![Coverage Status](https://coveralls.io/repos/jmcvetta/restclient/badge.png)](https://coveralls.io/r/jmcvetta/napping)
 


### PR DESCRIPTION
defunct drone.io CI badge removed from README